### PR TITLE
requirement on pyvista

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Convert OpenMC .vtk files to dolfinx functions"
 readme = "README/md"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
-dependencies = ["fenics-dolfinx>=0.9.0", "pyvista"]
+dependencies = ["fenics-dolfinx>=0.9.0", "pyvista<0.46"]
 classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
This pins the pyvista version because it seems like 0.46 brought some breaking changes.

We should try and fix it but in the meantime let's just pin it